### PR TITLE
Extract keyCode to frequency calculation to the Synthesizer

### DIFF
--- a/src/components/MusicalTyping.vue
+++ b/src/components/MusicalTyping.vue
@@ -21,7 +21,6 @@
     props: ['octave'],
     data() {
       return {
-        activeFrequencies: {},
         keys: [
           {
             letter: 'a',
@@ -156,10 +155,7 @@
         if (this.keyIsAValidNote(e.key) && !e.repeat) {
           let internalKey = this.keys.find(k => k.letter === e.key);
           internalKey.isActive = true;
-
-          const frequency = this.frequency(this.keyNumber(internalKey));
-          this.activeFrequencies[e.key] = frequency;
-          this.$emit('playNote', frequency);
+          this.$emit('keyDown', this.keyNumber(internalKey));
         }
       },
       stopNote(e) {
@@ -168,26 +164,13 @@
         let internalKey = this.keys.find(k => k.letter === e.key);
         internalKey.isActive = false;
 
-        const frequency = this.activeFrequencies[e.key];
-        delete this.activeFrequencies[e.key];
-
-        this.$emit('stopNote', frequency);
+        this.$emit('keyUp', this.keyNumber(internalKey));
       },
       keyIsAValidNote(key) {
         return this.keys.map(k => k.letter).includes(key);
       },
       keyNumber(key) {
         return key.stepsAboveRootOfOctave + this.octave * KEYS_IN_OCTAVE;
-      },
-      frequency(keyNumber) {
-        // The formula for converting a key of the piano to it's frequency in twelve-tone equal temperament:
-        // https://en.wikipedia.org/wiki/Piano_key_frequencies
-
-        const FOURTH_OCTAVE_A_KEY_NUMBER = 49;
-        const FREQUENCY_OF_FOURTH_OCTAVE_A = 440;
-
-        const power = (keyNumber - FOURTH_OCTAVE_A_KEY_NUMBER) / KEYS_IN_OCTAVE;
-        return Number((Math.pow(2, power) * FREQUENCY_OF_FOURTH_OCTAVE_A).toFixed(2));
       }
     },
     computed: {

--- a/tests/unit/Synthesizer.spec.js
+++ b/tests/unit/Synthesizer.spec.js
@@ -14,13 +14,16 @@ describe('Synthesizer', () => {
   });
 
   it('plays 880Hz when the A key pressed on default 4th octave', () => {
-    const playNoteStub = jest.fn();
+    const createOscillatorNodeStub = jest.fn().mockReturnValue({
+      connect: () => {},
+      start: () => {}
+    });
     const wrapper = mount(Synthesizer, {
       propsData: {
         audioContext: AudioContext
       },
       methods: {
-        playNote: playNoteStub,
+        createOscillatorNode: createOscillatorNodeStub,
       },
       attachToDocument: true,
     });
@@ -29,6 +32,6 @@ describe('Synthesizer', () => {
       key: 'h'
     });
 
-    expect(playNoteStub).toHaveBeenCalledWith(880);
+    expect(createOscillatorNodeStub).toHaveBeenCalledWith(880);
   });
 });


### PR DESCRIPTION
This refactor allows the Synthesizer.vue to receive a `keyCode` instead of a frequency in Hz, It uses the keyCode to calculate the frequency itself and generate the sound.

This refactor is useful because it will allow us to pass keyCodes to the Synthesizer.vue using the webmidi api, unlocking the world of external midi controllers!


**Details:**
Each key of the piano gets its own key code (for example 4th octave A is 49)
Example key numbers: https://www.inspiredacoustics.com/en/MIDI_note_numbers_and_center_frequencies

FYI There may be some tweaks required when testing with real midi controllers, there doesn't appear to be a rock solid standard for mapping piano keys to numbers but we'll cross that bridge when we get to it