### PR TITLE
Add midi control

### DIFF
--- a/src/initializeMidi.js
+++ b/src/initializeMidi.js
@@ -1,0 +1,23 @@
+const MIDI_KEYCODE_OFFSET = 20;
+const KEY_DOWN = 144;
+const KEY_UP = 128;
+const COMMAND = 0;
+const NOTE = 1;
+
+export default async function initializeMidi(playNote, stopNote) {
+    const access = await navigator.requestMIDIAccess();
+    Array.from(access.inputs.values()).forEach(input => {
+        input.onmidimessage = message => {
+            const data = message.data;
+
+            if (data[COMMAND] === KEY_DOWN) {
+                playNote(data[NOTE] - MIDI_KEYCODE_OFFSET)
+                return
+            }
+
+            if (data[COMMAND] === KEY_UP) {
+                stopNote(data[NOTE] - MIDI_KEYCODE_OFFSET)
+            }
+        }
+    });
+}

--- a/src/views/Synthesizer.vue
+++ b/src/views/Synthesizer.vue
@@ -93,6 +93,7 @@
 import shapeMap from '@/shapes';
 import Arpeggiator from '@/components/Arpeggiator';
 import MusicalTyping from "../components/MusicalTyping";
+import initializeMidi from "@/initializeMidi";
 
 export default {
   components: {MusicalTyping},
@@ -125,6 +126,9 @@ export default {
     soundShape() {
       return shapeMap[this.shape];
     }
+  },
+  async created() {
+    await initializeMidi(this.playNote, this.stopNote);
   },
   methods: {
     changeOctave(step) {

--- a/tests/unit/Synthesizer.spec.js
+++ b/tests/unit/Synthesizer.spec.js
@@ -1,9 +1,10 @@
-import { shallowMount, mount } from '@vue/test-utils'
+import {shallowMount, mount} from '@vue/test-utils'
 import Synthesizer from '@/views/Synthesizer.vue'
 import AudioContext from '../mocks/AudioContext';
 
 describe('Synthesizer', () => {
   it('renders', () => {
+    navigator.requestMIDIAccess = jest.fn().mockResolvedValue({ inputs: [] });
     const wrapper = shallowMount(Synthesizer, {
       propsData: {
         audioContext: AudioContext,
@@ -14,6 +15,7 @@ describe('Synthesizer', () => {
   });
 
   it('plays 880Hz when the A key pressed on default 4th octave', () => {
+    navigator.requestMIDIAccess = jest.fn().mockResolvedValue({ inputs: [] });
     const createOscillatorNodeStub = jest.fn().mockReturnValue({
       connect: () => {},
       start: () => {}
@@ -33,5 +35,68 @@ describe('Synthesizer', () => {
     });
 
     expect(createOscillatorNodeStub).toHaveBeenCalledWith(880);
+  });
+
+  it('plays when a midi device plays middle C', async () => {
+    const device = {id: '1', state: 'connected', name: 'first', onmidimessage: null}
+    navigator.requestMIDIAccess = jest.fn().mockResolvedValue({ inputs: [ device ] });
+    const createOscillatorNodeStub = jest.fn().mockReturnValue({
+      connect: () => {},
+      start: () => {}
+    });
+
+    let wrapper = await mount(Synthesizer, {
+      propsData: {
+        audioContext: AudioContext
+      },
+      methods: {
+        createOscillatorNode: createOscillatorNodeStub,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    const KEY_DOWN_COMMAND = 144;
+    const MIDDLE_C_KEYCODE = 60;
+    const fakeMidiEvent = {data: [KEY_DOWN_COMMAND, MIDDLE_C_KEYCODE, 0]};
+
+    device.onmidimessage(fakeMidiEvent)
+
+    const MIDDLE_C_FREQUENCY = 261.63;
+    expect(createOscillatorNodeStub).toHaveBeenCalledWith(MIDDLE_C_FREQUENCY);
+  });
+
+  it('stops an oscillator when the midi device lifts middle C', async () => {
+    const device = {id: '1', state: 'connected', name: 'first', onmidimessage: null}
+    navigator.requestMIDIAccess = jest.fn().mockResolvedValue({ inputs: [ device ] });
+    const turnOffGainStub = jest.fn()
+    const findOscillatorByStub = jest.fn().mockReturnValue({
+      gainNode: {
+        gain: {
+          exponentialRampToValueAtTime: turnOffGainStub
+        }
+      }
+    });
+
+    let wrapper = await mount(Synthesizer, {
+      propsData: {
+        audioContext: AudioContext
+      },
+      methods: {
+        findOscillatorBy: findOscillatorByStub,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    const KEY_UP_COMMAND = 128;
+    const MIDDLE_C_KEYCODE = 60;
+    const fakeMidiEvent = {data: [KEY_UP_COMMAND, MIDDLE_C_KEYCODE, 0]};
+
+    device.onmidimessage(fakeMidiEvent)
+
+    const MIDDLE_C_FREQUENCY = 261.63;
+    expect(findOscillatorByStub).toHaveBeenCalledWith({ frequency: MIDDLE_C_FREQUENCY });
+    expect(turnOffGainStub).toHaveBeenCalled();
   });
 });

--- a/tests/unit/initializeMidi.spec.js
+++ b/tests/unit/initializeMidi.spec.js
@@ -1,0 +1,31 @@
+import initializeMidi from "@/initializeMidi";
+
+describe('initializeMidi', () => {
+  it('calls playNote callback when a key is pressed', async() => {
+    const device = {id: 1, state: 'connected', name: 'first', onmidimessage: null}
+    navigator.requestMIDIAccess = jest.fn().mockResolvedValue({inputs: [ device ]});
+
+    const playNote = jest.fn()
+    const stopNote = jest.fn()
+
+    await initializeMidi(playNote, stopNote)
+
+    device.onmidimessage({ data: [144, 60, 0] })
+
+    expect(playNote).toHaveBeenCalledWith(40)
+  });
+
+  it('calls stopNote callback when a key is lifted', async () => {
+    const device = {id: 1, state: 'connected', name: 'first', onmidimessage: null}
+    navigator.requestMIDIAccess = jest.fn().mockResolvedValue({inputs: [ device ]});
+
+    const playNote = jest.fn()
+    const stopNote = jest.fn()
+
+    await initializeMidi(playNote, stopNote)
+
+    device.onmidimessage({ data: [128, 60, 0] })
+
+    expect(stopNote).toHaveBeenCalledWith(40)
+  });
+});


### PR DESCRIPTION
This allows the user to plug in a usb midi controller (or a virtual midi controller on their computer) and play notes on voodoo synth.